### PR TITLE
Use log level to determine level of error to send Sentry

### DIFF
--- a/lib/ravenex/logger_backend.ex
+++ b/lib/ravenex/logger_backend.ex
@@ -31,8 +31,9 @@ defmodule Ravenex.LoggerBackend do
   defp post_event({Logger, msg, _ts, meta}, level, keys) do
     msg = IO.chardata_to_string(msg)
     meta = take_into_map(meta, keys)
-    meta = Map.put(meta, :level, level)
-    Ravenex.LoggerParser.parse(msg) |> Ravenex.Notifier.notify([params: meta])
+
+    Ravenex.LoggerParser.parse(msg)
+    |> Ravenex.Notifier.notify([level: level, params: meta])
   end
 
   defp take_into_map(metadata, keys) do


### PR DESCRIPTION
This patch changes `Ravenex.LoggerBackend` to send Sentry errors at the same level that the log was passed in as. That is, if we log at the `debug` level, we will report this to Sentry at the `debug` level as well (assuming that we've configured `logger_level` to be `debug`). We map the following levels:

| Elixir Logger Level | Sentry Level |
| --- | --- |
| debug | debug |
| info | info |
| warn | warning |
| error | error |

This does not affect notifications sent directly to the notifier.
