### PR TITLE
Ensure can use ravenex with poison 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 erl_crash.dump
 *.ez
 *.tar
+.DS_Store
+.elixir_ls/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Ravenex
 
+## 1.0.8
+
+* Ensure client can use poison 3.x
+
 ## 1.0.6
 
 * Ensure that Sentry gets the correct error level when passing errors via the logger backend

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ config :ravenex,
   dsn: {:system, "RAVEN_DSN"}
 ```
 
+### Scrubber configuration
+
+If you need to scrub data out of the error messages, you can configure regular
+expressions that will cleanse the data. The scrubber is configured in config/config.exs
+using regular expressions. The scrubber configuration is a tuple of a matching
+regular expression string along with a replacement string.
+
+```elixir
+# Example scrubber configuration
+config :revenex,
+  scrubbers: [
+    {"password: .+?(\n| )", "password: SCRUBBED\\1"},
+    {"scrubber regex 2", "scrubber 2 replacement"}
+  ]
+```
+Scrubbers are a list of tuples with a regular expression string at element one and a replacement string as the second element. The replacement regular expression can use capture groups which can be referenced in the replacement string.
+
 ## Usage
 
 ```elixir

--- a/lib/ravenex/exception_parser.ex
+++ b/lib/ravenex/exception_parser.ex
@@ -2,7 +2,7 @@ defmodule Ravenex.ExceptionParser do
   def parse(exception) do
     %{
       type: exception.__struct__,
-      message: Exception.message(exception),
+      message: MessageScrubber.scrub(Exception.message(exception)),
       backtrace: stacktrace(System.stacktrace)
     }
   end

--- a/lib/ravenex/logger_parser.ex
+++ b/lib/ravenex/logger_parser.ex
@@ -18,7 +18,7 @@ defmodule Ravenex.LoggerParser do
 
     %{
       type: type,
-      message: Enum.join(messages, "\n"),
+      message: MessageScrubber.scrub(Enum.join(messages, "\n")),
       backtrace: backtrace
     }
   end

--- a/lib/ravenex/message_scrubber.ex
+++ b/lib/ravenex/message_scrubber.ex
@@ -1,0 +1,28 @@
+defmodule MessageScrubber do
+  def start_link() do
+    Agent.start_link(fn ->
+      process_scrub_config()
+    end, name: __MODULE__)
+  end
+
+  def get_config() do
+    Agent.get(__MODULE__, fn(x) -> x end)
+  end
+
+  def scrub(message) when is_binary(message) do
+    Enum.reduce(get_config(), message, fn(c, acc) ->
+      Regex.replace(elem(c, 0), acc, elem(c, 1))
+    end)
+  end
+
+  defp process_scrub_config() do
+    case Application.get_env(:ravenex, :scrubbers) do
+      nil ->
+        []
+      config ->
+        Enum.map(config, fn(c) ->
+          { Regex.compile!(elem(c, 0), "i"), elem(c, 1) }
+        end)
+    end
+  end
+end

--- a/lib/ravenex/ravenex_app.ex
+++ b/lib/ravenex/ravenex_app.ex
@@ -1,0 +1,5 @@
+defmodule RavenexApp do
+  def start(_type, _args) do
+    RavenexSupervisor.start_link()
+  end
+end

--- a/lib/ravenex/ravenex_supervisor.ex
+++ b/lib/ravenex/ravenex_supervisor.ex
@@ -1,0 +1,15 @@
+defmodule RavenexSupervisor do
+  use Supervisor
+
+  def start_link(opts \\ []) do
+    Supervisor.start_link(__MODULE__, opts, name: RavenexSupervisor)
+  end
+
+  def init(opts) do
+    children = [
+      worker(MessageScrubber, [])
+    ]
+
+    supervise(children, [strategy: :one_for_one] ++ opts)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ravenex.Mixfile do
   def project do
     [
       app: :ravenex,
-      version: "0.0.7",
+      version: "0.0.8",
       elixir: "~> 1.0",
       description: """
         Ravenex is an Elixir client for Sentry. Automatically

--- a/mix.exs
+++ b/mix.exs
@@ -11,8 +11,8 @@ defmodule Ravenex.Mixfile do
         send error notifications to Sentry. Easily connects
         with Phoenix through adding a logger or Plug.
       """,
-      package: package,
-      deps: deps
+      package: package(),
+      deps: deps()
    ]
   end
 
@@ -26,12 +26,14 @@ defmodule Ravenex.Mixfile do
 
   def application do
     [
-      applications: [:idna, :hackney, :httpoison, :uuid]
+      applications: [:idna, :hackney, :httpoison, :uuid],
+      mod: { RavenexApp, [] }
     ]
   end
 
   defp deps do
     [
+      {:gen_retry, "~> 1.0.1", only: :test},
       {:httpoison, "~> 0.8"},
       {:poison, "~> 2.0"},
       {:uuid, "~> 1.1.3"},

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Ravenex.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.8"},
-      {:poison, "~> 2.0"},
+      {:poison, "~> 2.0 or ~> 3.0"},
       {:uuid, "~> 1.1.3"},
       {:ex_doc, "~> 0.14", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ravenex.Mixfile do
   def project do
     [
       app: :ravenex,
-      version: "0.0.8",
+      version: "0.0.9",
       elixir: "~> 1.0",
       description: """
         Ravenex is an Elixir client for Sentry. Automatically

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "uuid": {:hex, :uuid, "1.1.3", "06ca38801a1a95b751701ca40716bb97ddf76dfe7e26da0eec7dba636740d57a", [:mix], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
 %{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "exconstructor": {:hex, :exconstructor, "1.1.0", "272623a7b203cb2901c20cbb92c5c3ab103cc0087ff7c881979e046043346752", [], [], "hexpm"},
+  "gen_retry": {:hex, :gen_retry, "1.0.1", "420c513fba5bcb3b8cd3def345093bde39b53ef115212a7bcd3ff9602b8071c0", [], [{:exconstructor, "~> 1.0", [hex: :exconstructor, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.6.0", "8d1e9440c9edf23bf5e5e2fe0c71de03eb265103b72901337394c840eec679ac", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.8.3", "b675a3fdc839a0b8d7a285c6b3747d6d596ae70b6ccb762233a990d7289ccae4", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},

--- a/test/ravenex/exception_parser_test.exs
+++ b/test/ravenex/exception_parser_test.exs
@@ -1,6 +1,14 @@
 defmodule Ravenex.ExceptionParserTest do
   use ExUnit.Case
 
+  setup_all do
+    if Process.whereis(RavenexSupervisor) == nil do
+      Application.put_env(:ravenex, :scrubbers, nil)
+      RavenexSupervisor.start_link([max_restarts: 20])
+    end
+    :ok
+  end
+
   test "should parse exception" do
 
     exception = try do

--- a/test/ravenex/exception_parser_test.exs
+++ b/test/ravenex/exception_parser_test.exs
@@ -9,23 +9,19 @@ defmodule Ravenex.ExceptionParserTest do
       e -> e
     end
 
-    result = %{
+    assert %{
       backtrace: [
-        %{filename: "(Elixir.IO) lib/io.ex", function: "inspect(\"test\", [], \"\")", lineno: 258},
-        %{filename: "(Elixir.Ravenex.ExceptionParserTest) test/ravenex/exception_parser_test.exs", function: "test should parse exception/1", lineno: 7},
-        %{filename: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "exec_test/1", lineno: 296}, %{filename: "(timer) timer.erl", function: "tc/1", lineno: 166},
-        %{filename: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "-spawn_test/3-fun-1-/3", lineno: 246}
+        %{filename: "(Elixir.IO) lib/io.ex", function: "inspect(\"test\", [], \"\")", lineno: lineno1},
+        %{filename: "(Elixir.Ravenex.ExceptionParserTest) test/ravenex/exception_parser_test.exs", function: "test should parse exception/1", lineno: lineno2},
+        %{filename: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "exec_test/1", lineno: _}, %{filename: "(timer) timer.erl", function: "tc/1", lineno: lineno3},
+        %{filename: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "-spawn_test/3-fun-1-/3", lineno: lineno4}
       ],
       message: "no function clause matching in IO.inspect/3",
       type: FunctionClauseError
-    }
-
-    %{
-      backtrace: [],
-      message: "no function clause matching in IO.inspect/3",
-      type: FunctionClauseError
-    }
-
-    assert Ravenex.ExceptionParser.parse(exception) == result
+    } = Ravenex.ExceptionParser.parse(exception)
+    assert is_number(lineno1) and lineno1 > 0
+    assert is_number(lineno2) and lineno2 > 0
+    assert is_number(lineno3) and lineno3 > 0
+    assert is_number(lineno4) and lineno4 > 0
   end
 end

--- a/test/ravenex/logger_parser_test.exs
+++ b/test/ravenex/logger_parser_test.exs
@@ -1,6 +1,14 @@
 defmodule Ravenex.LoggerParserTest do
   use ExUnit.Case
 
+  setup_all do
+    if Process.whereis(RavenexSupervisor) == nil do
+      Application.put_env(:ravenex, :scrubbers, nil)
+      RavenexSupervisor.start_link([max_restarts: 20])
+    end
+    :ok
+  end
+
   test "should parse exception from logs" do
     exception = """
       an exception was raised:

--- a/test/ravenex/message_scrubber_test.exs
+++ b/test/ravenex/message_scrubber_test.exs
@@ -1,0 +1,73 @@
+defmodule MessageScrubberTest do
+  use ExUnit.Case
+
+  setup_all do
+    Supervisor.stop(RavenexSupervisor)
+    # Need to set max_restarts, otherwise the supervisor will be shutdown
+    # because of the numerous stop/start of the MessageScrubber.
+    RavenexSupervisor.start_link([max_restarts: 20])
+    :ok
+  end
+
+  test "Test scrubber with empty rules" do
+    Application.put_env(:ravenex, :scrubbers, nil)
+    restart_scrubber()
+    assert MessageScrubber.get_config() == []
+    assert MessageScrubber.scrub("testing") == "testing"
+  end
+
+  test "Test single scrubber rule" do
+    Application.put_env(:ravenex, :scrubbers, [{"a", "x" }])
+    restart_scrubber()
+    assert MessageScrubber.scrub("abc") == "xbc"
+  end
+
+  test "Test multiple scrubber rules" do
+    Application.put_env(:ravenex, :scrubbers, [{"a", "x" }, {"b", ""}])
+    restart_scrubber()
+    assert MessageScrubber.scrub("abc") == "xc"
+  end
+
+  test "LoggerParser.parse should use message scrubber" do
+    exception = """
+      an exception was raised:
+        ** (Ecto.NoResultsError) This error has password: pass
+    Another password: pass2 should be scrubbed
+    """
+    Application.put_env(:ravenex, :scrubbers, [{"password: .+?(\n| )", "password: SCRUBBED\\1" }])
+    restart_scrubber()
+    parsed = Ravenex.LoggerParser.parse(exception)
+
+    assert parsed.message == " This error has password: SCRUBBED\nAnother password: SCRUBBED should be scrubbed\n"
+  end
+
+  test "ExceptionParser.parse should use message scrubber" do
+    exception = try do
+      raise """
+       This error has password: pass
+      Another password: pass2 should be scrubbed
+      """
+    rescue
+      e -> e
+    end
+
+    Application.put_env(:ravenex, :scrubbers, [{"password: .+?(\n| )", "password: SCRUBBED\\1" }])
+    restart_scrubber()
+    parsed = Ravenex.ExceptionParser.parse(exception)
+
+    assert parsed.message == " This error has password: SCRUBBED\nAnother password: SCRUBBED should be scrubbed\n"
+  end
+
+  defp restart_scrubber() do
+    Process.whereis(MessageScrubber) |> Agent.stop()
+
+    t = GenRetry.Task.async( fn ->
+      case Process.whereis(MessageScrubber) do
+        nil -> raise "not done"
+        _ -> true
+      end
+    end, retries: 10, delay: 150 )
+
+    Task.await(t)
+  end
+end

--- a/test/ravenex/notifier_test.exs
+++ b/test/ravenex/notifier_test.exs
@@ -20,13 +20,18 @@ defmodule Ravenex.NotifierTest do
     assert notification[:environment] == nil
     assert List.first(notification[:exception])[:type] == FunctionClauseError
     assert List.first(notification[:exception])[:value] == "no function clause matching in IO.inspect/3"
-    assert List.first(notification[:exception])[:stacktrace][:frames] == [
-        %{filename: "(Elixir.IO) lib/io.ex", function: "inspect(\"test\", [], \"\")", lineno: 258},
+    assert [
+        %{filename: "(Elixir.IO) lib/io.ex", function: "inspect(\"test\", [], \"\")", lineno: lineno1},
         %{filename: "(Elixir.Ravenex.NotifierTest) test/ravenex/notifier_test.exs",
-          function: "test should correctly serialize exception/1", lineno: 9},
-        %{filename: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "exec_test/1", lineno: 296},
-        %{filename: "(timer) timer.erl", function: "tc/1", lineno: 166},
-        %{filename: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "-spawn_test/3-fun-1-/3", lineno: 246}]
+          function: "test should correctly serialize exception/1", lineno: lineno2},
+        %{filename: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "exec_test/1", lineno: lineno3},
+        %{filename: "(timer) timer.erl", function: "tc/1", lineno: lineno4},
+        %{filename: "(Elixir.ExUnit.Runner) lib/ex_unit/runner.ex", function: "-spawn_test/3-fun-1-/3", lineno: lineno5}] = List.first(notification[:exception])[:stacktrace][:frames]
+    assert is_number(lineno1) and lineno1 > 0
+    assert is_number(lineno2) and lineno2 > 0
+    assert is_number(lineno3) and lineno3 > 0
+    assert is_number(lineno4) and lineno4 > 0
+    assert is_number(lineno5) and lineno5 > 0
     assert notification[:extra] == %{}
     assert notification[:level] == "error"
     assert notification[:logger] == "Ravenex"
@@ -62,12 +67,17 @@ defmodule Ravenex.NotifierTest do
     assert notification[:environment] == nil
     assert List.first(notification[:exception])[:type] == "Ecto.NoResultsError"
     assert List.first(notification[:exception])[:value] == " expected at least one result but got none in query:\n\nfrom g in Test.Game,\n  where: g.id == ^\"d8fe9f04-8fda-4d8f-9473-67ba94dc9458\"\n\n"
-    assert List.first(notification[:exception])[:stacktrace][:frames] == [
-      %{"filename" => "(ecto) lib/ecto/repo/queryable.ex", "function" => " Ecto.Repo.Queryable.one!/4", "lineno" => 57},
-      %{"filename" => "(test) web/channels/game_channel.ex", "function" => " Test.GameChannel.join/3", "lineno" => 15},
-      %{"filename" => "(phoenix) lib/phoenix/channel/server.ex", "function" => " Phoenix.Channel.Server.init/1", "lineno" => 154},
-      %{"filename" => "(stdlib) gen_server.erl", "function" => " :gen_server.init_it/6", "lineno" => 328},
-      %{"filename" => "(stdlib) proc_lib.erl", "function" => " :proc_lib.init_p_do_apply/3", "lineno" => 239}]
+    assert [
+      %{"filename" => "(ecto) lib/ecto/repo/queryable.ex", "function" => " Ecto.Repo.Queryable.one!/4", "lineno" => lineno1},
+      %{"filename" => "(test) web/channels/game_channel.ex", "function" => " Test.GameChannel.join/3", "lineno" => lineno2},
+      %{"filename" => "(phoenix) lib/phoenix/channel/server.ex", "function" => " Phoenix.Channel.Server.init/1", "lineno" => lineno3},
+      %{"filename" => "(stdlib) gen_server.erl", "function" => " :gen_server.init_it/6", "lineno" => lineno4},
+      %{"filename" => "(stdlib) proc_lib.erl", "function" => " :proc_lib.init_p_do_apply/3", "lineno" => lineno5}] = List.first(notification[:exception])[:stacktrace][:frames]
+    assert is_number(lineno1) and lineno1 > 0
+    assert is_number(lineno2) and lineno2 > 0
+    assert is_number(lineno3) and lineno3 > 0
+    assert is_number(lineno4) and lineno4 > 0
+    assert is_number(lineno5) and lineno5 > 0
     assert notification[:extra] == %{}
     assert notification[:level] == "error"
     assert notification[:logger] == "Ravenex"


### PR DESCRIPTION
Now, we can not use ravenex and poison 3.x (dependencies conflict), so I changed on mix.exs.

I also changed the tests to do not break when running on different elixir versions.